### PR TITLE
Shortened outro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,49 @@
 # Concluding remarks
 
-We have taught a lot, but it is just a starting point.  What can you
-do next?
-
-
-## Thank you to all...
-- **Exercise leaders**
+## Thank you
+- Participants
+- Team leaders and hosts
 - Instructors
 - Collaborative document question answerers
 - Local partners
-- Other helpers
-- Attendees
 
-Please send a pull request to the workshop webpage if you are not
-listed and would like to be.
+You make these workshops possible and enjoyable <3
 
-
-## If you attended...
-
-### Feedback
+## Feedback
 
 **All feedback welcome and encouraged**:
-- Collaborative document: like usual
-- email, support@coderefinery.org
-- sticky notes (in-person)
-- https://coderefinery.org/organization/contact/ (including our chat)
+- Collaborative document
+- E-mail: support@coderefinery.org
+- Chat: https://coderefinery.zulipchat.com
 
+**Changes to the lesson material**/ unclear exercise instructions/ broken links:
+- Issues and pull requests very welcome: https://github.com/coderefinery/
 
-### Register if you haven't yet (and want to support us)
+We develop the workshop materials and format further based on your feedback and questions!
 
-- **Registering will help with our funding and reports**: Find link
-  from https://coderefinery.org/
-- You will receive a post-workshop survey of how your work has been
-  affected.
-- (though we support the right to attend anonymously)
+At some point in the future, you will receive a **post-workshop survey** of how your work has been affected by visiting this workshop. Please answer it.
 
+## Keep studying / ask for support 
 
-
-## If you want to keep studying / want more help...
-
-We have only started here, there is plenty to still learn.
-
+We have only started here, there is plenty to still learn and explore.
 
 ### Bring your own code session
 
 * **Bring your own code and we'll look at it together**
-* Next two Monday afternoons, 15-16:30 CEST
+* Next two Tuesday afternoons, 13-15:00 CEST
 * Zoom link will be sent to registered learners
 
-
-### Review / learn yourself later
+### Review
 
 - Main list: https://coderefinery.org/lessons/
 - All open source and will continue to be updated
 - Videos will stay on YouTube
 - We encourage re-use, re-teaching, etc.
-- ... the whole workshop is teaching how the lessons are made
-
 
 ### Ask for local support from partners
+
 These partners can provide support / Q&A / etc for what we have taught
-and have local training.  (There are probably more that we don't know
+and have local related training.  (There are probably more that we don't know
 about).
 
 * **Finland**
@@ -69,6 +52,7 @@ about).
     * Research Software Engineers provide close support for anything we
       have covered in this workshop: https://scicomp.aalto.fi/rse/
   * **CSC - IT Center for Science (Finland)**: https://research.csc.fi/
+    * Weekly user support session: https://ssl.eventilla.com/usersupportcoffee
     * Training calendar: https://www.csc.fi/en/training#training-calendar
 * **Sweden**
   * **National Academic Infrastructure for Supercomputing in Sweden**,
@@ -80,131 +64,35 @@ about).
     * Training: https://documentation.sigma2.no/training/events.html
 * And many more
 
+## Certificates
 
-### Upcoming courses we would like to highlight
+If you would like a **certificate**, please check the [course webpage](https://coderefinery.github.io/2024-03-12-workshop/) for instructions.
 
-There are *many* training courses in the links above.  Here are a few
-courses we would like to highlight (important and most have
-registration open to the public):
-
-* Follow-ups: Bring Your Own Code sessions on 2 and 9 October at
-  16EEST / 15 CEST.  Same Zoom as exercise sessions.
-
-
-* [Python for Scientific
-  Computing](https://scicomp.aalto.fi/training/scip/python-for-scicomp-2023/),
-  7-11 Nov 2023.
-  * Livestream, many of the same people as here.
-  * We want ~1000 registrations and 10 local partners to do this! -
-    help us.
-* [Julia for High-Performance Scientific Computing](https://enccs.se/events/10-2023-julia-for-hpc/)
-  * Online, 10-13 October
-* Workflows course (livestream) in February (?)
-  * How do researchers actually use all of these tools together?
-* [Scientific Computing / HPC
-  kickstart](https://scicomp.aalto.fi/training/),
-  (~first week of June, next in 2024)
-  * Livestream, Aalto University, relevant to everyone.
-* EuroHPC National Competence Center Sweden,
-  [ENCCS](https://enccs.se/)
-  * Many upcoming events: https://enccs.se/events/
-  * Public training material: https://enccs.se/lessons/
-* Norwegian Research Infrastructure Services: https://www.sigma2.no/nris
-  * [NRIS Training](https://documentation.sigma2.no/training/events.html#training-events)
-* CSC - The IT Center for Science (Finland)
-  * [Elements of
-    SuperComputing](https://edukamu.fi/elements-of-supercomputing) - self-learning
-  * [Research data
-    management](https://ssl.eventilla.com/event/v8B6B) - self-learning
-* **CodeRefinery**
-  * Next online in March-May 2023 (?)
-
-
-
-## If you want a certificate...
-
-If you would like a **certificate**, please check the course webpage
-for instructions depending on your location.
-
-
-
-## If you want a EU-hosted alternative to Github: source.coderefinery.org
-
-CodeRefinery has a cross-Nordic GitLab service: https://source.coderefinery.org:
-
-- to be able to create projects/groups, please write support@coderefinery.org
-- everybody can join existing projects without asking us
-
-
-
-## If you want to help CodeRefinery...
+## Support CodeRefinery
 
 - **Tell everyone about us.** #CodeRefinery, Mastodon:
   [@coderefinery@fosstodon.org](https://fosstodon.org/@coderery)
-  Twitter: [@coderefine](https://twitter.com/coderefine)
+  Twitter: [@coderefine](https://twitter.com/coderefine) , LinkedIn: [CodeRefinery](https://www.linkedin.com/company/coderefinery-research-software-development)
 
-- **Come back as an Exercise Leader.** Bring your group, learn together.
-- **Bring your whole organization.** Organize local groups.
+- **Come back as an Team Leader.** Bring your group, learn together.
+- **Become part of the team** CodeRefinery lives from **in-kind** contributions by organizations (your organization sponsors your worktime to the project)
 
+## Get involved in CodeRefinery
 
+CodeRefinery community lives in the **Zulip chat**: https://coderefinery.zulipchat.com
 
-## If you want to get involved in CodeRefinery...
+Follow what we do by signing up to our **newsletter**: https://coderefinery.org/#newsletter
 
-**We can use diverse types of team members.**  We have plenty to do
-beyond teaching.
+## Got interested in Research Software Development?
 
-**Join our meetings**
-* https://coderefinery.org/join/meetings/ - Monday afternoons
-
-CodeRefinery chat: https://coderefinery.zulipchat.com
-* #help stream, give and ask advice.
-
-
-### Join as an individual
-
-- As an individual, teach or do whatever you want:
-  https://coderefinery.org/join/individuals/
-
-**If you would like to get involved** in teaching/tutoring/material or even event organization:
-- If you would like to participate as helper or instructor in future
-  workshops, please register to our newsletter: https://coderefinery.org/#newsletter
-- You can also write to us, every contribution most welcome
-- If you would like to reuse some of our material for your own workshops, we can probably support you
-- https://coderefinery.github.io/manuals/
-
-**Changes to the lesson material**/ unclear exercise instructions/ broken links:
-- Issues and pull requests very welcome: https://github.com/coderefinery/
-- We usually go through all issues latest before each workshop and are happy to
-  hear about anything that could be improved from participant view
-
-
-### Join as an organization
-https://coderefinery.org/join/organizations/
-
-- **Run your own breakout rooms** (in-person or online)
-- Systematically advertise to your audience
-- Offer certificates
-- Improve your own teaching with CodeRefinery teaching strategies.
-- Share your teaching work, don't re-invent everything: get
-  co-teachers and more attendees.
-
-
-
-## If you want to make a career out of software...
-
-### Nordic Research Software Engineers
+### Join the Nordic Research Software Engineers ([Nordic-RSE](https://nordic-rse.org))
 
 A **Research Software Engineer** combines research knowledge with
 software development experience, just like we have learned here.
 
 - Community, seminar series, and other events.
 - Chat (part of CodeRefinery chat): https://coderefinery.zulipchat.com, `#nordic-rse`
-- Online unconference, 25-26 October: https://nordic-rse.org/events/2023-online-unconference/
+- [Nordic-RSE conference](https://nordic-rse.org/events/2024-in-person-conference/): May 30-31 in Espoo, Finland
 - https://twitter.com/nordic_rse
-- NordicRSE members can be found here: https://nordic-rse.org/map/
-
-
-## Link to instructor Zoom will be posted if you want to talk to us now.
-
 
 ## Thank you!

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ about).
     * Weekly user support session: https://ssl.eventilla.com/usersupportcoffee
     * Training calendar: https://www.csc.fi/en/training#training-calendar
 * **Sweden**
-  * **National Academic Infrastructure for Supercomputing in Sweden**,
+  * **National Academic Infrastructure for Supercomputing in Sweden**:
     https://www.naiss.se/
   * **EuroCC National Competence Center Sweden**: https://enccs.se/
     * Upcoming events: https://enccs.se/events/


### PR DESCRIPTION
fixes #21 

- removed upcoming trainings, links to training calendars are provided in partner section
- shortened "get involved" (thinking about what particpants can do rather than organizations)
- removed gitlab
- added linkedin
- updated NRSE section with conference date

How about other CR partners, Denmark etc? Something to add about Spain and NL groups?